### PR TITLE
add basic setup.py and fix demo.py to work with py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+from setuptools import setup, find_packages
+
+setup(name='devol',
+    version='0.01',
+    description='Automated deep neural network design via genetic programming.',
+    url='https//github.com/joedav/devol',
+    author='Joe Davidson',
+    author_email='josephddavison@gmail.com',
+    license='MIT',
+
+    classifiers=[
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 3 - Alpha',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+
+        # Pick your license as you wish (should match "license" above)
+         'License :: OSI Approved :: MIT License',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    keywords='genetic algorithms',
+
+    install_requires=['keras',
+                      'tensorflow',
+                      'tqdm'
+                     ],
+)


### PR DESCRIPTION
Fixed demo.py to work with python 3.

Add a basic setup.py so the library can be installed with `pip install -e ~/path/to/devol` so the library can be used in other places. The `-e` flag installs the library in development mode so that you can `git pull` to update as the library progresses. 

TODO: 
1. Probably should suggest this in the "How to use" section of the Readme.
2. `tensorflow` may not be needed in the setup.py file but I prefer it. 