### PR TITLE
When performing validation use a subset of training data

### DIFF
--- a/devol/devol.py
+++ b/devol/devol.py
@@ -150,7 +150,7 @@ class DEvol:
         loss, accuracy = None, None
         try:
             model.fit(self.x_train, self.y_train,
-                      validation_data=(self.x_test, self.y_test),
+                      validation_split=0.1,
                       epochs=epochs,
                       verbose=1,
                       callbacks=[


### PR DESCRIPTION
Hey, currently DEvol uses testing data as validation data, which means that the final model will be biased. Wouldn't it be better to just split 10% of training data and use that as a validation data?