### PR TITLE
minor changes

### DIFF
--- a/devol/genome_handler.py
+++ b/devol/genome_handler.py
@@ -135,8 +135,10 @@ class GenomeHandler:
         if not self.is_compatible_genome(genome):
             raise ValueError("Invalid genome for specified configs")
         model = Sequential()
+        dim = 0
         offset = 0
-        dim = min(self.input_shape[:-1]) # keep track of smallest dimension
+        if self.convolution_layers > 0:
+            dim = min(self.input_shape[:-1]) # keep track of smallest dimension
         input_layer = True
         for i in range(self.convolution_layers):
             if genome[offset]:


### PR DESCRIPTION
It appears to be broken for NAS without conv nets. 

Since when only using dense the shape is usually only 1 dimensional. Hence

```python
dim = min(self.input_shape[:-1]) # keep track of smallest dimension
```

 will be on an empty sequence and min on a empty sequence raises an error. 

This is just the quick fix i did to fix it. 